### PR TITLE
Loosened spacing restrictions on directive

### DIFF
--- a/lib/SSI.js
+++ b/lib/SSI.js
@@ -5,10 +5,6 @@ var glob = require("glob");
 var IOUtils = require("./IOUtils");
 var DirectiveHandler = require("./DirectiveHandler");
 
-// Match only trailing space
-//var DIRECTIVE_MATCHER = /<!--#([a-z]+)([ ]+([a-z]+)="(.+?)")* -->/g;
-
-// Match (or dont) a leading space or trailing space before or after the directive
 var DIRECTIVE_MATCHER = /<!--[ ]*#([a-z]+)([ ]+([a-z]+)="(.+?)")*[ ]*-->/g;
 
 (function() {

--- a/lib/SSI.js
+++ b/lib/SSI.js
@@ -5,7 +5,11 @@ var glob = require("glob");
 var IOUtils = require("./IOUtils");
 var DirectiveHandler = require("./DirectiveHandler");
 
-var DIRECTIVE_MATCHER = /<!--#([a-z]+)([ ]+([a-z]+)="(.+?)")* -->/g;
+// Match only trailing space
+//var DIRECTIVE_MATCHER = /<!--#([a-z]+)([ ]+([a-z]+)="(.+?)")* -->/g;
+
+// Match (or dont) a leading space or trailing space before or after the directive
+var DIRECTIVE_MATCHER = /<!--[ ]*#([a-z]+)([ ]+([a-z]+)="(.+?)")*[ ]*-->/g;
 
 (function() {
 	"use strict";


### PR DESCRIPTION
Changed the matching pattern for gleaning SSI directive instances so that spaces can exist before or after the directive inside the comment.  This change conforms to some of the rules that Microsoft IIS has.

I know that on the Apache site, all of the examples show SSI of the structure: 
```
<!--#echo var="DATE_LOCAL" -->
```

Where there is only a space directly after the directive.  I'm not sure if this is an absolute structural requirement, but I was trying to port some server code from an IIS server to a node.js server and tried to use your plugin.  I fought with getting anything to print out for a couple of hours only to throw your regex into a regex tester to test against one of my directives.  That let me figure out what was going wrong with regard to the spacing.

Because of that, I'm asking to loosen the directive matching regular expression so that there can be either a leading or trailing space character which works in IIS.  I don't know if it's a Microsoft specific nuance, or whether or not the spacing is a defined format, all I know is that the relaxation might save someone from potentially running into the issue I had.